### PR TITLE
MessageBind has been depricated

### DIFF
--- a/Enable-MailboxAuditing.ps1
+++ b/Enable-MailboxAuditing.ps1
@@ -65,5 +65,5 @@ If($All) {
 ForEach ($User in $Users)
 {
     Write-Host "$(Get-Date) Setting audit enabled for user $($User.Identity)" -ForegroundColor Green
-    Set-Mailbox -Identity $User.Identity -AuditLogAgeLimit 90 -AuditEnabled $true -AuditAdmin UpdateCalendarDelegation,UpdateFolderPermissions,UpdateInboxRules,Update,Move,MoveToDeletedItems,SoftDelete,HardDelete,FolderBind,SendAs,SendOnBehalf,Create,Copy,MessageBind -AuditDelegate UpdateFolderPermissions,UpdateInboxRules,Update,Move,MoveToDeletedItems,SoftDelete,HardDelete,FolderBind,SendAs,SendOnBehalf,Create -AuditOwner UpdateCalendarDelegation,UpdateFolderPermissions,UpdateInboxRules,Update,MoveToDeletedItems,Move,SoftDelete,HardDelete,Create,MailboxLogin
+    Set-Mailbox -Identity $User.Identity -AuditLogAgeLimit 90 -AuditEnabled $true -AuditAdmin UpdateCalendarDelegation,UpdateFolderPermissions,UpdateInboxRules,Update,Move,MoveToDeletedItems,SoftDelete,HardDelete,FolderBind,SendAs,SendOnBehalf,Create,Copy,MailItemsAccessed -AuditDelegate UpdateFolderPermissions,UpdateInboxRules,Update,Move,MoveToDeletedItems,SoftDelete,HardDelete,FolderBind,SendAs,SendOnBehalf,Create -AuditOwner UpdateCalendarDelegation,UpdateFolderPermissions,UpdateInboxRules,Update,MoveToDeletedItems,Move,SoftDelete,HardDelete,Create,MailboxLogin
 }


### PR DESCRIPTION
MessageBind has been depricated and (at least with modern cmdlets) this throws an error.
Also see:
https://docs.microsoft.com/en-us/microsoft-365/compliance/enable-mailbox-auditing?view=o365-worldwide#mailbox-auditing-actions
"A message was viewed in the preview pane or opened by an admin. Note: Although this value is accepted as a mailbox action, these actions are no longer logged."

Associated Issue: https://github.com/MicrosoftDocs/OfficeDocs-o365seccomp/issues/286