### PR TITLE
Filter out deleted users

### DIFF
--- a/Get-InactiveUsers.ps1
+++ b/Get-InactiveUsers.ps1
@@ -108,12 +108,15 @@ Write-Host -ForegroundColor Green "$(Get-Date) Processing user data to prepare e
 
     foreach ($item in $result)
     {
-        $Return += New-Object -TypeName PSObject -Property @{
-            UserPrincipalName=$item.userprincipalname
-            AccountEnabled=$item.accountenabled
-            LastSignIn=$item.signinactivity.lastsignindatetime
-            UserType=$item.usertype
-        }
+	if ( $item.userPrincipalName -ne $null )
+	{
+		$Return += New-Object -TypeName PSObject -Property @{
+			UserPrincipalName=$item.userprincipalname
+			AccountEnabled=$item.accountenabled
+			LastSignIn=$item.signinactivity.lastsignindatetime
+			UserType=$item.usertype
+		}
+	}
     }
 
 # Exporting CSV


### PR DESCRIPTION
When using the $filter=signInActivity/lastSignInDateTime filter on the users endpoint, it will return deleted users too. Those will have a lastsignindatetime but all other properties will be empty. It creates confusion when looking at the report.
I suggest we simply filter out result without a UPN (indicating it is a deleted user).