### PR TITLE
Update SPO script and mailbox audit logging script

### DIFF
--- a/SharePoint/Get-SPOSiteAdmins.ps1
+++ b/SharePoint/Get-SPOSiteAdmins.ps1
@@ -11,23 +11,51 @@
 #documentation, even if Microsoft has been advised of the possibility of such damages.
 ############################################################################
 
+#Requires -Modules Microsoft.Online.SharePoint.PowerShell
+
+<#
+	.Synopsis
+		Help synposis
+	.Description
+		Help description
+	.Parameter OutputDir
+		Directory to save the output file.  Default is the current directory.
+	.Parameter SPOAdmin
+		UPN of the admin account that has, or will be granted, site admin permission (the latter
+		only if SPOPermissionOptOut is not True).
+	.Parameter SPOTenantName
+		Name of the tenant, which is the subdomain value of the .onmicrosoft.com domain, e.g.,
+		"contoso" for contoso.onmicrosoft.com.  If not already connected to SPO and the value is not
+		entered via the parameter, you will be asked to enter it in order to continue.
+	.Parameter SPOPermissionOptOut
+		If the SPOAdmin is needed to be added as a site admin to retrieve the list of site admins,
+		use this switch if you don't want to add the account as a site admin (and, therefore, skip
+		checking any site that would need the account added in order to perform the check).  If added,
+		the permission is removed after the site is checked.
+	.Notes
+		Version: 2.0
+		Date: June 22, 2021
+#>
+
 Param(
     [CmdletBinding()]
     [Parameter(Mandatory=$false)]
-    [String]$OutputDir,
-    [String]$SPOAdmin,
+    [String]$OutputDir = (Get-Location).Path,
+    [Parameter(Mandatory=$true)][String]$SPOAdmin,
     [String]$SPOTenantName,
-    [Switch]$SPOPermissionOptIn
+    [Switch]$SPOPermissionOptOut
 )
 
-Add-Type -TypeDefinition @"
-   public enum SiteCollectionAdminState
-   {
-        Needed,
-        NotNeeded,
-        Skip
-   }
+if (-not([System.Management.Automation.PSTypeName]'SiteCollectionAdminState').Type){
+	Add-Type -TypeDefinition @"
+	   public enum SiteCollectionAdminState
+	   {
+	        Needed,
+	        NotNeeded,
+	        Skip
+	   }
 "@
+}
 
 function Grant-SiteCollectionAdmin
 {
@@ -49,21 +77,18 @@ function Grant-SiteCollectionAdmin
 
     # Skip this site collection if the current user does not have permissions and
     # permission changes should not be made ($SPOPermissionOptOut)
-    if ($needsAdmin -and $SPOPermissionOptIn -eq $false)
+    if ($needsAdmin -and $SPOPermissionOptOut -eq $true)
     {
-        Write-Verbose "$(Get-Date) Grant-SiteCollectionAdmin Skipping $($Site.URL) Needs Admin $needsAdmin PermissionOptIn $SPOPermissionOptIn"
+        Write-Verbose "$(Get-Date) Grant-SiteCollectionAdmin Skipping $($Site.URL) Needs Admin $needsAdmin PermissionOptOut $SPOPermissionOptOut"
         [SiteCollectionAdminState]$adminState = [SiteCollectionAdminState]::Skip
     }
     # Grant access to the site collection, if required
     elseif ($needsAdmin)
     {
         try{
-            Write-Verbose "$(Get-Date) Grant-SiteCollectionAdmin Adding $($SPOAdmin) $($Site.URL) Needs Admin $needsAdmin PermissionOptIn $SPOPermissionOptIn"
+            Write-Verbose "$(Get-Date) Grant-SiteCollectionAdmin Adding $($SPOAdmin) $($Site.URL) Needs Admin $needsAdmin PermissionOptOut $SPOPermissionOptOut"
             Set-SPOUser -site $Site -LoginName $SPOAdmin -IsSiteCollectionAdmin $True | Out-Null
-    
-            # Workaround for a race condition that has PnP connect to SPO before the permission access is committed
-            Start-Sleep -Seconds 1
-    
+ 
             [SiteCollectionAdminState]$adminState = [SiteCollectionAdminState]::Needed
         }
         catch{
@@ -97,23 +122,31 @@ function Revoke-SiteCollectionAdmin
 
 function Get-SPOAdminsList
 {
-    $siteUrl = "https://$SPOTenantName-admin.sharepoint.com"
-    Write-Verbose "$(Get-Date) connect to tenant admin $($siteUrl)"
-    Connect-SPOService -Url $siteUrl
+    if (-not(Get-SpoTenant -ErrorAction SilentlyContinue)) {
+    	if (-not($SPOTenantName)){
+			$SPOTenantName = Read-Host -Prompt "Please enter the tenant name (without the .onmicrosoft.com suffix)"
+		}
+		$siteUrl = "https://$SPOTenantName-admin.sharepoint.com"
+		Write-Verbose "$(Get-Date) Connect to SPO tenant admin URL: $($siteUrl)"
+		Connect-SPOService -Url $siteUrl
+	}
 
-    #Get list of admins per site
-    $sites = Get-SPOSite -Limit All -IncludePersonalSite $true
+    #Get list of sites
+    [array]$sites = Get-SPOSite -Limit All -IncludePersonalSite $true
     $admins = @()
     $siteAdmins = @()
     
-    # Isolate the valid sites - Matches *.sharepoint.com/sites/*, *.sharepoint.com/teams/*, *.sharepoint.com
-    $validSites = $sites | `
-    Where-Object { $_.Url -match '((\.sharepoint\.com\/(sites|teams))|(^https:\/\/.+(?<!-my)\.sharepoint\.com\/?$))'}
-
+    # Exclude root site because it can take a very long time to get the list of users for the site
+    # Get domain for sites to support custom domain in sites' FQDN
+    $sitesDomain = $sites[0].Url.Substring(8,$sites[0].Url.IndexOf('/',8)-8)
+    $validSites = $sites | Where-Object {$_.url -match [regex]::Escape($sitesDomain)+"\/(sites|teams)"}
+	
+	$j = 1
     foreach ($site in $validSites)
     {
-        if($site.Template -ne "GROUP#0")
-        {
+        Write-Progress -Activity "SharePoint Collection" -Status "Site Collection Properties ($j of $($validSites.Count))" -CurrentOperation "$($site.Url)" -PercentComplete ($j/$validSites.Count * 100)        
+		#if($site.Template -ne "GROUP#0")
+		#{
             Write-Verbose "$(Get-Date) connecting to site $($site.Url)"
             Write-Verbose "$(Get-Date) Get-SPOAdminList Processing $($site.Url)"
             # Grant permission to the site collection, if needed AND allowed
@@ -124,28 +157,39 @@ function Get-SPOAdminsList
                 continue
             }
 
-            $siteAdmins = Get-SPOUser -Site $site -Limit ALL | Where-Object { $_.IsSiteAdmin -eq $true}
-            Write-Host "$(Get-Date) Get-SPOSiteCollectionProperties $site SiteAdmins $($siteAdmins.Count)"
+            $siteAdmins = Get-SPOUser -Site $site -Limit All | Where-Object { $_.IsSiteAdmin -eq $true}
             $count = $siteAdmins.Count
             
             $AdminList = @()
 
             for($i=0; $i -lt $count; $i++)
             {
-                $AdminList += $siteAdmins[$i].DisplayName
+				# Skip admin if listed only because of "admin needed"
+				if (-not($siteAdmins[$i].LoginName -eq $SpoAdmin -and $adminState -eq [SiteCollectionAdminState]::Needed)) {
+					# Include entry type
+					if ($siteAdmins[$i].IsGroup) {
+						$type = "Group"
+					}
+					else {
+						$type = "User"
+					}
+	                $AdminList += $siteAdmins[$i].DisplayName+" ($type)"
+				}
             }
             
-            $admins += New-Object psobject -Property @{
+            $admins += New-Object PSObject -Property @{
                 Url=$($site.Url)
                 Admins=$(@($AdminList) -join ',')
             }
+			
+			Write-Host "$(Get-Date) Site: $($site.Url) SiteAdminCount: $($AdminList.Count)"
                         
             # Cleanup permission changes, if any
             Revoke-SiteCollectionAdmin -Site $site -AdminState $adminState
-        }
-
+        #}
+	$j++
     }
-    $admins | Export-Csv "$OutputDir\admins_CSV.csv"
+    $admins | Export-Csv "$OutputDir\SPOSiteAdmins.csv" -NoTypeInformation
 
 }
 

--- a/SharePoint/Readme.md
+++ b/SharePoint/Readme.md
@@ -1,10 +1,10 @@
-This folder contains set of sample scripts to help you get further information from your SharePoint Online tenant. These scripts are provided for reference and example purposes only. Please ensure that you thoroughly review each script before executing it within your environment.
+This folder contains sample scripts to help you get additional information from your SharePoint Online tenant. These scripts are provided for reference and example purposes only. Please ensure that you thoroughly review each script before executing it within your environment.
 
 ### Get Admins for Site Collections
 
-ODSPControls_GetAdmins.ps1
+Get-SPOSiteAdmins.ps1
 
-This script iterates through all the SharePoint Site Collections except Groups Connected Team Sites and gets the list of admins for each site. If the user running the script does not admin rights on the Site Collectioni, script will add the user to the Site Collection as admin and after completion remove the added user.
+This script iterates through all the SharePoint Online site collections with a /sites or /teams path and gets the list of admin entries for each site. If the user running the script does not have site admin permission to the site collection, the script will add the user as a site admin to the site collection and then remove the user after the site has been checked.
 
 # Disclaimer
 


### PR DESCRIPTION
Updated SPO site admin script to correct inconsistent results compared to SOA collection script, updated the output to include the entry type (group or user), and added opt-in support for including OneDrive sites.  Updated the mailbox audit logging script name, added support for WhatIf (no changes made to mailboxes, but the logging will still occur as if they were changed), and changed the audit logging actions to be opt in (and changed parameter name because of that).